### PR TITLE
Updated MCP tooling

### DIFF
--- a/src/IonBlazor.Mcp/Resources/ComponentModels.cs
+++ b/src/IonBlazor.Mcp/Resources/ComponentModels.cs
@@ -23,9 +23,10 @@ public sealed record ComponentMetadata(
     IReadOnlyList<ComponentEvent> Events,
     IReadOnlyList<ComponentBind> Binds,
     IReadOnlyList<ComponentMethod> JsMethods,
+    IReadOnlyList<ValueSetMetadata> ValueSets,
     string? Description = null);
 
-public sealed record ComponentParameter(string Name, string TypeName, string? Description = null);
+public sealed record ComponentParameter(string Name, string TypeName, string? ValueSetName = null, string? Description = null);
 
 public sealed record ComponentCascadingParameter(string Name, string TypeName, string? CascadingName, string? Description = null);
 

--- a/src/IonBlazor.Mcp/Resources/ComponentRegistry.cs
+++ b/src/IonBlazor.Mcp/Resources/ComponentRegistry.cs
@@ -46,20 +46,35 @@ public static class ComponentRegistry
         BindProperties: GetBinds(type).Select(b => b.PropertyName).ToList(),
         Description: XmlDocReader.GetSummary(type));
 
-    private static ComponentMetadata BuildMetadata(Type type) => new(
-        Name: GetDisplayName(type),
-        FullName: type.FullName ?? type.Name,
-        BaseClass: GetBaseClassName(type),
-        HasChildContent: HasChildContent(type),
-        HasJsInterop: typeof(IonJsComponent).IsAssignableFrom(type),
-        JsImportName: GetJsImportName(type),
-        Interfaces: GetIonInterfaces(type),
-        Parameters: GetParameters(type),
-        CascadingParameters: GetCascadingParameters(type),
-        Events: GetEvents(type),
-        Binds: GetBinds(type),
-        JsMethods: GetJsMethods(type),
-        Description: XmlDocReader.GetSummary(type));
+    private static ComponentMetadata BuildMetadata(Type type)
+    {
+        var parameters = GetParameters(type);
+        var valueSets = parameters
+            .Where(p => p.ValueSetName is not null)
+            .Select(p => p.ValueSetName!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .Select(ValueSetRegistry.GetMetadata)
+            .Where(m => m is not null)
+            .Select(m => m!)
+            .ToList();
+
+        return new ComponentMetadata(
+            Name: GetDisplayName(type),
+            FullName: type.FullName ?? type.Name,
+            BaseClass: GetBaseClassName(type),
+            HasChildContent: HasChildContent(type),
+            HasJsInterop: typeof(IonJsComponent).IsAssignableFrom(type),
+            JsImportName: GetJsImportName(type),
+            Interfaces: GetIonInterfaces(type),
+            Parameters: parameters,
+            CascadingParameters: GetCascadingParameters(type),
+            Events: GetEvents(type),
+            Binds: GetBinds(type),
+            JsMethods: GetJsMethods(type),
+            ValueSets: valueSets,
+            Description: XmlDocReader.GetSummary(type));
+    }
 
     private static string GetDisplayName(Type type)
     {
@@ -114,10 +129,19 @@ public static class ComponentRegistry
         var nullCtx = new NullabilityInfoContext();
         return GetParameterProperties(type)
             .Where(p => !IsEventCallback(p.PropertyType))
-            .Select(p => new ComponentParameter(p.Name, TypeFormatter.FormatProperty(p, nullCtx), XmlDocReader.GetSummary(p)))
+            .Select(p => new ComponentParameter(
+                p.Name,
+                TypeFormatter.FormatProperty(p, nullCtx),
+                ResolveValueSetName(type, p),
+                XmlDocReader.GetSummary(p)))
             .OrderBy(p => p.Name, StringComparer.Ordinal)
             .ToList();
     }
+
+    private static string? ResolveValueSetName(Type componentType, PropertyInfo prop) =>
+        prop.PropertyType == typeof(string)
+            ? ValueSetRegistry.ResolveForProperty(componentType, prop.Name)
+            : null;
 
     private static IReadOnlyList<ComponentCascadingParameter> GetCascadingParameters(Type type)
     {

--- a/src/IonBlazor.Mcp/Resources/ServiceModels.cs
+++ b/src/IonBlazor.Mcp/Resources/ServiceModels.cs
@@ -25,6 +25,18 @@ public sealed record ServiceOptions(
     string Name,
     string FullName,
     IReadOnlyList<ServiceOptionProperty> Properties,
+    IReadOnlyList<ServiceOptionBuilder> Builders,
     string? Description = null);
 
-public sealed record ServiceOptionProperty(string Name, string TypeName, string? Description = null);
+public sealed record ServiceOptionProperty(
+    string Name,
+    string TypeName,
+    string? DefaultValue = null,
+    string? Description = null);
+
+public sealed record ServiceOptionBuilder(
+    string PropertyName,
+    string DelegateSignature,
+    string BuilderTypeName,
+    IReadOnlyList<ServiceMethod> BuilderMethods,
+    string? Description = null);

--- a/src/IonBlazor.Mcp/Resources/ServiceRegistry.cs
+++ b/src/IonBlazor.Mcp/Resources/ServiceRegistry.cs
@@ -112,21 +112,117 @@ public static class ServiceRegistry
     private static ServiceOptions BuildOptions(Type optionsType)
     {
         var nullCtx = new NullabilityInfoContext();
-        var properties = optionsType
+        var instance = TryCreateInstance(optionsType);
+
+        var allProps = optionsType
             .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
             .Where(p => p.GetMethod is { IsPublic: true })
             .Where(p => p.SetMethod is { IsPublic: true })
-            .Select(p => new ServiceOptionProperty(
+            .ToList();
+
+        var properties = new List<ServiceOptionProperty>();
+        var builders = new List<ServiceOptionBuilder>();
+
+        foreach (var p in allProps)
+        {
+            if (TryBuildBuilder(p, nullCtx) is { } builder)
+            {
+                builders.Add(builder);
+                continue;
+            }
+
+            properties.Add(new ServiceOptionProperty(
                 p.Name,
                 TypeFormatter.FormatProperty(p, nullCtx),
-                XmlDocReader.GetSummary(p)))
-            .OrderBy(p => p.Name, StringComparer.Ordinal)
-            .ToList();
+                FormatDefault(ReadDefault(instance, p)),
+                XmlDocReader.GetSummary(p)));
+        }
 
         return new ServiceOptions(
             Name: optionsType.Name,
             FullName: optionsType.FullName ?? optionsType.Name,
-            Properties: properties,
+            Properties: properties.OrderBy(p => p.Name, StringComparer.Ordinal).ToList(),
+            Builders: builders.OrderBy(b => b.PropertyName, StringComparer.Ordinal).ToList(),
             Description: XmlDocReader.GetSummary(optionsType));
+    }
+
+    private static object? TryCreateInstance(Type type)
+    {
+        try { return Activator.CreateInstance(type); }
+        catch { return null; }
+    }
+
+    private static object? ReadDefault(object? instance, PropertyInfo prop)
+    {
+        if (instance is null) return null;
+        try { return prop.GetValue(instance); }
+        catch { return null; }
+    }
+
+    private static string? FormatDefault(object? value) => value switch
+    {
+        null => null,
+        string s => $"\"{s}\"",
+        bool b => b ? "true" : "false",
+        _ => value.ToString(),
+    };
+
+    /// <summary>
+    /// If the property is a builder-style delegate (a delegate whose invocation receives a fluent
+    /// <c>*Builder</c> instance), expands the delegate signature and the builder's public methods.
+    /// Returns null for plain data and callback (event-args) delegate properties.
+    /// </summary>
+    private static ServiceOptionBuilder? TryBuildBuilder(PropertyInfo prop, NullabilityInfoContext nullCtx)
+    {
+        var type = prop.PropertyType;
+        if (!typeof(Delegate).IsAssignableFrom(type))
+            return null;
+
+        var invoke = type.GetMethod("Invoke");
+        if (invoke is null)
+            return null;
+
+        var parameters = invoke.GetParameters();
+        var builderParam = parameters.FirstOrDefault(
+            p => p.ParameterType.Name.EndsWith("Builder", StringComparison.Ordinal));
+        if (builderParam is null)
+            return null;
+
+        var paramList = string.Join(", ",
+            parameters.Select(p => $"{TypeFormatter.FormatParameter(p, nullCtx)} {p.Name}"));
+        var signature = $"{TypeFormatter.Format(invoke.ReturnType)} ({paramList})";
+
+        return new ServiceOptionBuilder(
+            PropertyName: prop.Name,
+            DelegateSignature: signature,
+            BuilderTypeName: builderParam.ParameterType.Name,
+            BuilderMethods: BuildInstanceMethods(builderParam.ParameterType),
+            Description: XmlDocReader.GetSummary(prop));
+    }
+
+    private static IReadOnlyList<ServiceMethod> BuildInstanceMethods(Type type)
+    {
+        var nullCtx = new NullabilityInfoContext();
+        return type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName)
+            .Where(m => m.GetCustomAttribute<ObsoleteAttribute>() is null)
+            .Select(m => new ServiceMethod(
+                FormatMethodName(m),
+                TypeFormatter.Format(m.ReturnType),
+                m.GetParameters()
+                    .Select(p => new ServiceMethodParameter(p.Name ?? "_", TypeFormatter.FormatParameter(p, nullCtx)))
+                    .ToList(),
+                XmlDocReader.GetSummary(m)))
+            .OrderBy(m => m.Name, StringComparer.Ordinal)
+            .ThenBy(m => m.Parameters.Count)
+            .ToList();
+    }
+
+    private static string FormatMethodName(MethodInfo m)
+    {
+        if (!m.IsGenericMethodDefinition)
+            return m.Name;
+        var args = string.Join(", ", m.GetGenericArguments().Select(a => a.Name));
+        return $"{m.Name}<{args}>";
     }
 }

--- a/src/IonBlazor.Mcp/Resources/ValueSetModels.cs
+++ b/src/IonBlazor.Mcp/Resources/ValueSetModels.cs
@@ -1,0 +1,18 @@
+namespace IonBlazor.Mcp.Resources;
+
+public sealed record ValueSetSummary(
+    string Name,
+    string FullName,
+    int ValueCount,
+    string? Description = null);
+
+public sealed record ValueSetMetadata(
+    string Name,
+    string FullName,
+    IReadOnlyList<ValueSetEntry> Values,
+    string? Description = null);
+
+public sealed record ValueSetEntry(
+    string ConstantName,
+    string? Value,
+    string? Description = null);

--- a/src/IonBlazor.Mcp/Resources/ValueSetRegistry.cs
+++ b/src/IonBlazor.Mcp/Resources/ValueSetRegistry.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using IonBlazor.Abstractions;
+
+namespace IonBlazor.Mcp.Resources;
+
+public static class ValueSetRegistry
+{
+    private const string ComponentsNamespace = "IonBlazor.Components";
+    private const string IonPrefix = "Ion";
+
+    private static readonly Lazy<IReadOnlyList<Type>> _valueSetTypes = new(DiscoverValueSets);
+    private static readonly Lazy<IReadOnlyDictionary<string, Type>> _byName =
+        new(() => _valueSetTypes.Value.ToDictionary(t => t.Name, t => t, StringComparer.Ordinal));
+
+    public static IReadOnlyList<ValueSetSummary> ListAll() =>
+        _valueSetTypes.Value
+            .Select(BuildSummary)
+            .OrderBy(s => s.Name, StringComparer.Ordinal)
+            .ToList();
+
+    public static ValueSetMetadata? GetMetadata(string name)
+    {
+        if (!_byName.Value.TryGetValue(name, out Type? type))
+            return null;
+        return BuildMetadata(type);
+    }
+
+    /// <summary>
+    /// Resolves the value-set class associated with a string-typed property on a component, using the
+    /// IonBlazor naming conventions. Returns the value-set class name (e.g. "IonInputType") or null
+    /// if no matching set exists.
+    /// </summary>
+    public static string? ResolveForProperty(Type componentType, string propertyName)
+    {
+        var rawComponentName = componentType.Name;
+        var tick = rawComponentName.IndexOf('`');
+        if (tick >= 0) rawComponentName = rawComponentName[..tick];
+
+        var suffix = rawComponentName.StartsWith(IonPrefix, StringComparison.Ordinal)
+            ? rawComponentName[IonPrefix.Length..]
+            : rawComponentName;
+
+        // Most specific first → least specific last.
+        var candidates = new[]
+        {
+            IonPrefix + suffix + propertyName,   // e.g. IonInputType, IonRangeLabelPlacement
+            IonPrefix + propertyName,            // e.g. IonMode, IonColor (cross-component)
+            suffix + propertyName,               // e.g. SearchbarAutoComplete (no Ion prefix)
+        };
+
+        foreach (var candidate in candidates)
+        {
+            if (_byName.Value.ContainsKey(candidate))
+                return candidate;
+        }
+        return null;
+    }
+
+    private static IReadOnlyList<Type> DiscoverValueSets()
+    {
+        var assembly = typeof(IonComponent).Assembly;
+        return assembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: true, IsSealed: true, IsPublic: true })
+            .Where(t => t.Namespace == ComponentsNamespace)
+            .Where(t => t.GetCustomAttribute<ObsoleteAttribute>() is null)
+            .Where(IsValueSet)
+            .ToList();
+    }
+
+    private static bool IsValueSet(Type type)
+    {
+        var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        if (fields.Length == 0)
+            return false;
+
+        foreach (var field in fields)
+        {
+            if (!field.IsLiteral || field.IsInitOnly)
+                return false;
+            if (field.FieldType != typeof(string))
+                return false;
+        }
+
+        // Reject extension/helper classes that happen to also expose const strings.
+        var declaredMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        return declaredMethods.All(m => m.IsSpecialName);
+    }
+
+    private static ValueSetSummary BuildSummary(Type type) => new(
+        Name: type.Name,
+        FullName: type.FullName ?? type.Name,
+        ValueCount: GetValueFields(type).Count,
+        Description: XmlDocReader.GetSummary(type));
+
+    private static ValueSetMetadata BuildMetadata(Type type) => new(
+        Name: type.Name,
+        FullName: type.FullName ?? type.Name,
+        Values: GetValueFields(type)
+            .Select(f => new ValueSetEntry(
+                ConstantName: f.Name,
+                Value: (string?)f.GetRawConstantValue(),
+                Description: XmlDocReader.GetSummary(f)))
+            .ToList(),
+        Description: XmlDocReader.GetSummary(type));
+
+    private static IReadOnlyList<FieldInfo> GetValueFields(Type type) =>
+        type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(f => f is { IsLiteral: true, IsInitOnly: false })
+            .Where(f => f.FieldType == typeof(string))
+            .OrderBy(f => f.Name, StringComparer.Ordinal)
+            .ToList();
+}

--- a/src/IonBlazor.Mcp/Resources/XmlDocReader.cs
+++ b/src/IonBlazor.Mcp/Resources/XmlDocReader.cs
@@ -46,6 +46,15 @@ internal static class XmlDocReader
         return ResolveInheritedPropertySummary(prop, docs);
     }
 
+    public static string? GetSummary(FieldInfo field)
+    {
+        var id = GetFieldXmlId(field);
+        if (id is null) return null;
+
+        var docs = _docs.Value;
+        return docs.Summaries.TryGetValue(id, out var direct) ? direct : null;
+    }
+
     public static string? GetSummary(MethodInfo method)
     {
         var id = GetMethodXmlId(method);
@@ -260,6 +269,15 @@ internal static class XmlDocReader
             return null;
         var typeName = GetTypeNameForXmlId(declaring);
         return typeName is null ? null : $"P:{typeName}.{prop.Name}";
+    }
+
+    private static string? GetFieldXmlId(FieldInfo field)
+    {
+        var declaring = field.DeclaringType;
+        if (declaring is null)
+            return null;
+        var typeName = GetTypeNameForXmlId(declaring);
+        return typeName is null ? null : $"F:{typeName}.{field.Name}";
     }
 
     private static string? GetMethodXmlId(MethodInfo method)

--- a/src/IonBlazor.Mcp/Tools/ComponentTools.cs
+++ b/src/IonBlazor.Mcp/Tools/ComponentTools.cs
@@ -124,12 +124,12 @@ public static class ComponentTools
           .AppendLine(meta.Interfaces.Count == 0 ? "(none)" : string.Join(", ", meta.Interfaces.Select(i => $"`{i}`")));
         sb.AppendLine();
 
-        sb.AppendLine("> **Slots & arbitrary attributes:** Ionic named slots are not component parameters. Every");
+        sb.AppendLine("> **Slots & arbitrary attributes:** Ionic named slots are not component parameters. `slot` is");
+        sb.AppendLine("> a standard global HTML attribute (Shadow DOM), so it is handled like `id` or `class` — every");
         sb.AppendLine("> IonBlazor component captures unmatched attributes via `[Parameter(CaptureUnmatchedValues");
-        sb.AppendLine("> = true)] AdditionalAttributes`, so a named slot is a de-facto HTML attribute — place");
-        sb.AppendLine("> content into one with `slot=\"start\"` / `slot=\"end\"` on the child element, exactly as you");
-        sb.AppendLine("> would pass `id` or `class`. The valid slot names per component are Ionic web-component");
-        sb.AppendLine("> metadata; see the Ionic docs for the wrapped element.");
+        sb.AppendLine("> = true)] AdditionalAttributes`. Place content into a slot with `slot=\"start\"` / `slot=\"end\"`");
+        sb.AppendLine("> on the child element. The valid slot *names* per component are defined by the wrapped Ionic");
+        sb.AppendLine("> web component; see the Ionic docs for that element.");
         sb.AppendLine();
 
         AppendBinds(sb, meta);

--- a/src/IonBlazor.Mcp/Tools/ComponentTools.cs
+++ b/src/IonBlazor.Mcp/Tools/ComponentTools.cs
@@ -12,8 +12,8 @@ public static class ComponentTools
 
     [McpServerTool, Description(
         "Lists every IonBlazor component along with its base class, JS-interop status, " +
-        "child-content support, and the marker interfaces it implements " +
-        "(IIonModeComponent, IIonColorComponent, etc.).")]
+        "child-content support, the marker interfaces it implements " +
+        "(IIonModeComponent, IIonColorComponent, etc.), and its two-way @bind-able properties.")]
     public static string ListComponents()
     {
         var components = ComponentRegistry.ListAll();
@@ -21,8 +21,8 @@ public static class ComponentTools
         var sb = new StringBuilder();
         sb.Append("# IonBlazor Components (").Append(components.Count).AppendLine(")");
         sb.AppendLine();
-        sb.AppendLine("| Name | Base | JS | ChildContent | Interfaces |");
-        sb.AppendLine("| --- | --- | --- | --- | --- |");
+        sb.AppendLine("| Name | Base | JS | ChildContent | Interfaces | @bind |");
+        sb.AppendLine("| --- | --- | --- | --- | --- | --- |");
 
         foreach (var c in components)
         {
@@ -31,6 +31,7 @@ public static class ComponentTools
               .Append(" | ").Append(c.HasJsInterop ? "Yes" : "-")
               .Append(" | ").Append(c.HasChildContent ? "Yes" : "-")
               .Append(" | ").Append(c.Interfaces.Count == 0 ? "-" : string.Join(", ", c.Interfaces))
+              .Append(" | ").Append(c.BindProperties.Count == 0 ? "-" : string.Join(", ", c.BindProperties))
               .AppendLine(" |");
         }
 
@@ -123,11 +124,20 @@ public static class ComponentTools
           .AppendLine(meta.Interfaces.Count == 0 ? "(none)" : string.Join(", ", meta.Interfaces.Select(i => $"`{i}`")));
         sb.AppendLine();
 
+        sb.AppendLine("> **Slots & arbitrary attributes:** Ionic named slots are not component parameters. Every");
+        sb.AppendLine("> IonBlazor component captures unmatched attributes via `[Parameter(CaptureUnmatchedValues");
+        sb.AppendLine("> = true)] AdditionalAttributes`, so a named slot is a de-facto HTML attribute — place");
+        sb.AppendLine("> content into one with `slot=\"start\"` / `slot=\"end\"` on the child element, exactly as you");
+        sb.AppendLine("> would pass `id` or `class`. The valid slot names per component are Ionic web-component");
+        sb.AppendLine("> metadata; see the Ionic docs for the wrapped element.");
+        sb.AppendLine();
+
         AppendBinds(sb, meta);
         AppendParameters(sb, meta);
         AppendCascadingParameters(sb, meta);
         AppendEvents(sb, meta);
         AppendJsMethods(sb, meta);
+        AppendValueSets(sb, meta);
 
         return sb.ToString();
     }
@@ -162,14 +172,49 @@ public static class ComponentTools
             sb.AppendLine();
             return;
         }
-        sb.AppendLine("| Name | Type | Description |");
-        sb.AppendLine("| --- | --- | --- |");
+        sb.AppendLine("| Name | Type | Value set | Description |");
+        sb.AppendLine("| --- | --- | --- | --- |");
         foreach (var p in meta.Parameters)
             sb.Append("| ").Append(p.Name)
               .Append(" | `").Append(p.TypeName).Append('`')
+              .Append(" | ").Append(p.ValueSetName is null ? "-" : $"`{p.ValueSetName}`")
               .Append(" | ").Append(FormatCellDescription(p.Description))
               .AppendLine(" |");
         sb.AppendLine();
+    }
+
+    private static void AppendValueSets(StringBuilder sb, ComponentMetadata meta)
+    {
+        if (meta.ValueSets.Count == 0)
+            return;
+
+        sb.AppendLine("## Value sets");
+        sb.AppendLine();
+        sb.AppendLine("These static classes hold the conventional `const string` values for the matching `string` parameters above.");
+        sb.AppendLine("They are advisory — the parameters accept any `string`, which keeps the surface forward-compatible with");
+        sb.AppendLine("future Ionic updates.");
+        sb.AppendLine();
+
+        foreach (var vs in meta.ValueSets)
+        {
+            sb.Append("### `").Append(vs.Name).AppendLine("`");
+            sb.AppendLine();
+            if (!string.IsNullOrEmpty(vs.Description))
+            {
+                sb.AppendLine(vs.Description);
+                sb.AppendLine();
+            }
+            sb.AppendLine("| Constant | Value | Description |");
+            sb.AppendLine("| --- | --- | --- |");
+            foreach (var v in vs.Values)
+            {
+                sb.Append("| `").Append(vs.Name).Append('.').Append(v.ConstantName).Append('`')
+                  .Append(" | ").Append(v.Value is null ? "`null`" : $"`\"{v.Value}\"`")
+                  .Append(" | ").Append(FormatCellDescription(v.Description))
+                  .AppendLine(" |");
+            }
+            sb.AppendLine();
+        }
     }
 
     private static void AppendCascadingParameters(StringBuilder sb, ComponentMetadata meta)

--- a/src/IonBlazor.Mcp/Tools/ServiceTools.cs
+++ b/src/IonBlazor.Mcp/Tools/ServiceTools.cs
@@ -14,13 +14,20 @@ public static class ServiceTools
         "Lists every IonBlazor static service controller (IonActionSheetController, IonAlertController, " +
         "IonLoadingController, IonToastController) along with the associated *Options type and the number of " +
         "public static methods. Use this for queries like 'how do I show a toast programmatically' or " +
-        "'which IonBlazor overlay services exist'.")]
+        "'which IonBlazor overlay services exist'. Important: each controller is a ComponentBase subclass " +
+        "that must be rendered once at the app root (e.g. App.razor or MainLayout.razor) before its static " +
+        "methods can be invoked — call GetServiceMetadata for the exact setup snippet.")]
     public static string ListServices()
     {
         var services = ServiceRegistry.ListAll();
 
         var sb = new StringBuilder();
         sb.Append("# IonBlazor Services (").Append(services.Count).AppendLine(")");
+        sb.AppendLine();
+        sb.AppendLine("> Each controller below is a `ComponentBase` subclass, not a DI service. The static");
+        sb.AppendLine("> methods only work after the controller's tag has been rendered once at the app root");
+        sb.AppendLine("> (e.g. `<IonAlertController />` in `App.razor` or `MainLayout.razor`). That render");
+        sb.AppendLine("> captures `IJSRuntime` into a static field used by every subsequent static call.");
         sb.AppendLine();
         sb.AppendLine("| Name | Options | Methods | Description |");
         sb.AppendLine("| --- | --- | --- | --- |");
@@ -38,11 +45,13 @@ public static class ServiceTools
     }
 
     [McpServerTool, Description(
-        "Returns full metadata for a single IonBlazor service controller: type-level summary, all public " +
-        "static methods (signatures, parameters, return types, summaries), and the associated *Options " +
-        "record's properties (name, type, summary). Use this to learn the exact API for " +
-        "IonAlertController.PresentAsync, IonToastController.PresentAsync, IonLoadingController.CreateAsync, etc. " +
-        "Service name must be exact PascalCase, e.g. 'IonToastController'.")]
+        "Returns full metadata for a single IonBlazor service controller: type-level summary, the required " +
+        "host-component setup snippet, all public static methods (signatures, parameters, return types, " +
+        "summaries), and the associated *Options record — every property with its type, default value and " +
+        "summary, plus any builder properties expanded to their delegate signature and the fluent builder's " +
+        "public methods (e.g. ButtonsBuilder/InputsBuilder). Use this to learn the exact API for " +
+        "IonAlertController.PresentAsync, IonToastController.PresentAsync, IonLoadingController.CreateAsync, " +
+        "etc. Service name must be exact PascalCase, e.g. 'IonToastController'.")]
     public static string GetServiceMetadata(
         [Description("Exact service name, e.g. 'IonActionSheetController', 'IonAlertController', 'IonLoadingController', 'IonToastController'.")]
         string serviceName)
@@ -64,10 +73,30 @@ public static class ServiceTools
             sb.Append("- **Options type:** `").Append(meta.Options.Name).AppendLine("`");
         sb.AppendLine();
 
+        AppendSetup(sb, meta);
         AppendMethods(sb, meta);
         AppendOptions(sb, meta);
 
         return sb.ToString();
+    }
+
+    private static void AppendSetup(StringBuilder sb, ServiceMetadata meta)
+    {
+        sb.AppendLine("## Setup");
+        sb.AppendLine();
+        sb.Append("`").Append(meta.Name).AppendLine("` is a `ComponentBase` subclass, not a DI service. It injects");
+        sb.AppendLine("`IJSRuntime` and caches it into a static field during its first render — every static");
+        sb.AppendLine("method below reads that field, so the controller's tag MUST be rendered once at the app");
+        sb.AppendLine("root before any static call. Without it, `PresentAsync` will throw `NullReferenceException`.");
+        sb.AppendLine();
+        sb.AppendLine("Place the tag once in `App.razor` (or `MainLayout.razor`):");
+        sb.AppendLine();
+        sb.AppendLine("```razor");
+        sb.Append('<').Append(meta.Name).AppendLine(" />");
+        sb.AppendLine("```");
+        sb.AppendLine();
+        sb.AppendLine("Then call the static methods from anywhere in the app — no DI registration needed.");
+        sb.AppendLine();
     }
 
     private static void AppendMethods(StringBuilder sb, ServiceMetadata meta)
@@ -110,21 +139,69 @@ public static class ServiceTools
 
         if (opts.Properties.Count == 0)
         {
-            sb.AppendLine("(no public read/write properties)");
+            sb.AppendLine("(no public read/write data properties)");
             sb.AppendLine();
-            return;
+        }
+        else
+        {
+            sb.AppendLine("| Property | Type | Default | Description |");
+            sb.AppendLine("| --- | --- | --- | --- |");
+            foreach (var p in opts.Properties)
+            {
+                sb.Append("| ").Append(p.Name)
+                  .Append(" | `").Append(p.TypeName).Append('`')
+                  .Append(" | ").Append(p.DefaultValue is null ? "-" : $"`{p.DefaultValue}`")
+                  .Append(" | ").Append(FormatCellDescription(p.Description))
+                  .AppendLine(" |");
+            }
+            sb.AppendLine();
         }
 
-        sb.AppendLine("| Property | Type | Description |");
-        sb.AppendLine("| --- | --- | --- |");
-        foreach (var p in opts.Properties)
-        {
-            sb.Append("| ").Append(p.Name)
-              .Append(" | `").Append(p.TypeName).Append('`')
-              .Append(" | ").Append(FormatCellDescription(p.Description))
-              .AppendLine(" |");
-        }
+        AppendOptionBuilders(sb, opts);
+    }
+
+    private static void AppendOptionBuilders(StringBuilder sb, ServiceOptions opts)
+    {
+        if (opts.Builders.Count == 0)
+            return;
+
+        sb.AppendLine("### Builders");
         sb.AppendLine();
+        sb.AppendLine("Builder properties take a delegate that configures a fluent builder. Assign them like any");
+        sb.AppendLine("other option property; the delegate receives the builder instance to call the methods below.");
+        sb.AppendLine();
+
+        foreach (var b in opts.Builders)
+        {
+            sb.Append("#### `").Append(b.PropertyName).Append("` — `").Append(b.DelegateSignature).AppendLine("`");
+            sb.AppendLine();
+            if (!string.IsNullOrEmpty(b.Description))
+            {
+                sb.AppendLine(b.Description);
+                sb.AppendLine();
+            }
+            sb.Append("Configures `").Append(b.BuilderTypeName).AppendLine("`:");
+            sb.AppendLine();
+
+            if (b.BuilderMethods.Count == 0)
+            {
+                sb.AppendLine("(no public methods)");
+                sb.AppendLine();
+                continue;
+            }
+
+            sb.AppendLine("| Method | Returns | Description |");
+            sb.AppendLine("| --- | --- | --- |");
+            foreach (var m in b.BuilderMethods)
+            {
+                var paramList = string.Join(", ", m.Parameters.Select(p => $"{p.TypeName} {p.Name}"));
+                sb.Append("| `").Append(m.Name).Append('(').Append(paramList).Append(")`")
+                  .Append(" | `").Append(m.ReturnType).Append('`')
+                  .Append(" | ").Append(FormatCellDescription(m.Description))
+                  .AppendLine(" |");
+            }
+            sb.AppendLine();
+        }
     }
 
     private static string FormatCellDescription(string? description)

--- a/src/IonBlazor.Mcp/Tools/ValueSetTools.cs
+++ b/src/IonBlazor.Mcp/Tools/ValueSetTools.cs
@@ -1,0 +1,99 @@
+using System.ComponentModel;
+using System.Text;
+using IonBlazor.Mcp.Resources;
+using ModelContextProtocol.Server;
+
+namespace IonBlazor.Mcp.Tools;
+
+[McpServerToolType]
+public static class ValueSetTools
+{
+    private const int InlineDescriptionMaxLength = 140;
+
+    [McpServerTool, Description(
+        "Lists every IonBlazor value-set class — static classes in IonBlazor.Components that hold the " +
+        "conventional `const string` values for `string`-typed component parameters (e.g. IonMode, IonColor, " +
+        "IonInputType, IonRippleEffectType, IonRangeLabelPlacement). Parameters accept any string at runtime, " +
+        "so these classes are advisory rather than enums — the design intentionally keeps the surface " +
+        "forward-compatible with future Ionic releases. Use this for queries like 'what values can the " +
+        "color attribute take' or 'list every Ionic mode option'.")]
+    public static string ListValueSets()
+    {
+        var sets = ValueSetRegistry.ListAll();
+
+        var sb = new StringBuilder();
+        sb.Append("# IonBlazor Value Sets (").Append(sets.Count).AppendLine(")");
+        sb.AppendLine();
+        sb.AppendLine("> Each entry is a `public static class` of `public const string?` values. They are not");
+        sb.AppendLine("> enums — IonBlazor's `string` parameters accept arbitrary values so the surface stays");
+        sb.AppendLine("> compatible across Ionic versions. Use `GetValueSet` for the full constant list.");
+        sb.AppendLine();
+        sb.AppendLine("| Name | Values | Description |");
+        sb.AppendLine("| --- | --- | --- |");
+
+        foreach (var s in sets)
+        {
+            sb.Append("| ").Append(s.Name)
+              .Append(" | ").Append(s.ValueCount)
+              .Append(" | ").Append(FormatCellDescription(s.Description))
+              .AppendLine(" |");
+        }
+
+        return sb.ToString();
+    }
+
+    [McpServerTool, Description(
+        "Returns every constant in a single IonBlazor value-set class — constant name, the literal string " +
+        "value it maps to, and the XML doc summary where present. Use this for the exact options behind a " +
+        "parameter like IonInput.Type (IonInputType), IonApp.Mode (IonMode), or IonRippleEffect.Type " +
+        "(IonRippleEffectType). Value-set name must be exact PascalCase, e.g. 'IonInputType'.")]
+    public static string GetValueSet(
+        [Description("Exact value-set class name, e.g. 'IonMode', 'IonColor', 'IonInputType', 'IonRippleEffectType'.")]
+        string name)
+    {
+        var meta = ValueSetRegistry.GetMetadata(name);
+        if (meta is null)
+            return $"Value set '{name}' not found. Use ListValueSets to see the full inventory.";
+
+        var sb = new StringBuilder();
+        sb.Append("# ").AppendLine(meta.Name);
+        sb.AppendLine();
+        if (!string.IsNullOrEmpty(meta.Description))
+        {
+            sb.AppendLine(meta.Description);
+            sb.AppendLine();
+        }
+        sb.Append("- **Full name:** `").Append(meta.FullName).AppendLine("`");
+        sb.Append("- **Constants:** ").Append(meta.Values.Count).AppendLine();
+        sb.AppendLine();
+
+        if (meta.Values.Count == 0)
+        {
+            sb.AppendLine("(no constants)");
+            return sb.ToString();
+        }
+
+        sb.AppendLine("| Constant | Value | Description |");
+        sb.AppendLine("| --- | --- | --- |");
+        foreach (var v in meta.Values)
+        {
+            sb.Append("| `").Append(meta.Name).Append('.').Append(v.ConstantName).Append('`')
+              .Append(" | ").Append(v.Value is null ? "`null`" : $"`\"{v.Value}\"`")
+              .Append(" | ").Append(FormatCellDescription(v.Description))
+              .AppendLine(" |");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatCellDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return "-";
+
+        var single = description.Replace('\r', ' ').Replace('\n', ' ').Replace("|", "\\|");
+        if (single.Length > InlineDescriptionMaxLength)
+            single = single[..(InlineDescriptionMaxLength - 1)] + "…";
+        return single;
+    }
+}


### PR DESCRIPTION
Introduce `ValueSetTools` and `ValueSetRegistry` for listing and retrieving IonBlazor value-sets, enhancing developer introspection. Extend `ServiceRegistry` and `ComponentRegistry` with value-set awareness.