### PR TITLE
[feat] Added @bind-Value support to IonInputOtp

### DIFF
--- a/src/IonBlazor.Components/Components/IonInputOtp/IonInputOtp.razor.cs
+++ b/src/IonBlazor.Components/Components/IonInputOtp/IonInputOtp.razor.cs
@@ -131,6 +131,15 @@ public sealed partial class IonInputOtp : IonJsContentComponent, IIonColorCompon
     public EventCallback<IonInputOtp> IonFocus { get; set; }
 
     /// <summary>
+    /// Fires alongside <see cref="IonComplete"/> with the new <see cref="Value"/>, enabling
+    /// <c>@bind-Value</c>. With plain <c>@bind-Value</c> the bound value is updated only once all
+    /// input boxes are filled; use <c>@bind-Value:event="ValueInput"</c> (see <see cref="ValueInput"/>)
+    /// for live, per-keystroke binding instead.
+    /// </summary>
+    [Parameter]
+    public EventCallback<string?> ValueChanged { get; set; }
+
+    /// <summary>
     /// The ionInput event is fired each time the user modifies the input's value. Unlike the ionChange event, the
     /// ionInput event is fired for each alteration to the input's value. This typically happens for each keystroke as
     /// the user types.
@@ -140,6 +149,14 @@ public sealed partial class IonInputOtp : IonJsContentComponent, IIonColorCompon
     /// </summary>
     [Parameter]
     public EventCallback<IonInputOtpInputEventArgs> IonInputEvent { get; set; }
+
+    /// <summary>
+    /// Fires alongside <see cref="IonInputEvent"/> with the new <see cref="Value"/> on every keystroke.
+    /// Use with <c>@bind-Value:event="ValueInput"</c> for live (per-keystroke) two-way binding;
+    /// otherwise <c>@bind-Value</c> alone updates only once all boxes are filled via <see cref="ValueChanged"/>.
+    /// </summary>
+    [Parameter]
+    public EventCallback<string?> ValueInput { get; set; }
 
     public IonInputOtp()
     {
@@ -158,6 +175,8 @@ public sealed partial class IonInputOtp : IonJsContentComponent, IIonColorCompon
         _ionCompleteReference = IonicEventCallback<JsonObject?>.Create(async args =>
         {
             var value = args?["detail"]?["value"]?.GetValue<string?>();
+            Value = value;
+            await ValueChanged.InvokeAsync(value);
             await IonComplete.InvokeAsync(new IonInputOtpCompleteEventArgs { Sender = this, Value = value });
         });
 
@@ -170,6 +189,8 @@ public sealed partial class IonInputOtp : IonJsContentComponent, IIonColorCompon
         {
             var value = args?["detail"]?["value"]?.GetValue<string?>();
             var isTrusted = args?["detail"]?["event"]?["isTrusted"]?.GetValue<bool>() is true;
+            Value = value;
+            await ValueInput.InvokeAsync(value);
             await IonInputEvent.InvokeAsync(new IonInputOtpInputEventArgs { Sender = this, Value = value, Event = new IonInputEvent(isTrusted) });
         });
     }

--- a/tests/IonBlazor.UnitTests/Components/IonInputOtp/IonInputOtpTests.cs
+++ b/tests/IonBlazor.UnitTests/Components/IonInputOtp/IonInputOtpTests.cs
@@ -106,6 +106,61 @@ public class IonInputOtpTests : IonTestContext
     }
 
     // ---------------------------------------------------------------------------
+    // @bind-Value: parallel ValueChanged + IonComplete callbacks
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task IonComplete_FiresBoth_ValueChangedAndIonComplete()
+    {
+        string? capturedValue = null;
+        IonInputOtpCompleteEventArgs? capturedArgs = null;
+
+        var cut = Render<IonInputOtp>(parameters => parameters
+            .Add(p => p.ValueChanged, v => capturedValue = v)
+            .Add(p => p.IonComplete, args => capturedArgs = args));
+
+        var payload = new System.Text.Json.Nodes.JsonObject
+        {
+            ["detail"] = new System.Text.Json.Nodes.JsonObject
+            {
+                ["value"] = "1234"
+            }
+        };
+        await InvokeIonEventAsync("ionComplete", payload);
+
+        capturedValue.Should().Be("1234");
+        capturedArgs.Should().NotBeNull();
+        capturedArgs!.Value.Should().Be("1234");
+        cut.Instance.Value.Should().Be("1234");
+    }
+
+    [Fact]
+    public async Task IonInput_FiresBoth_ValueInputAndIonInput()
+    {
+        string? capturedValue = null;
+        IonInputOtpInputEventArgs? capturedArgs = null;
+
+        var cut = Render<IonInputOtp>(parameters => parameters
+            .Add(p => p.ValueInput, v => capturedValue = v)
+            .Add(p => p.IonInputEvent, args => capturedArgs = args));
+
+        var payload = new System.Text.Json.Nodes.JsonObject
+        {
+            ["detail"] = new System.Text.Json.Nodes.JsonObject
+            {
+                ["value"] = "12",
+                ["event"] = new System.Text.Json.Nodes.JsonObject { ["isTrusted"] = true }
+            }
+        };
+        await InvokeIonEventAsync("ionInput", payload);
+
+        capturedValue.Should().Be("12");
+        capturedArgs.Should().NotBeNull();
+        capturedArgs!.Value.Should().Be("12");
+        cut.Instance.Value.Should().Be("12");
+    }
+
+    // ---------------------------------------------------------------------------
     // JsImportName
     // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Add `ValueChanged` and `ValueInput` EventCallbacks to `IonInputOtp` with parallel `@bind-Value` support. Expand tests for `IonComplete` and `IonInput` event handling.