### PR TITLE
Remove dead ValueType cascade from IonSelect

### DIFF
--- a/src/IonBlazor.Components/Components/IonSelect/Abstractions/IonSelectOptionBase`1.cs
+++ b/src/IonBlazor.Components/Components/IonSelect/Abstractions/IonSelectOptionBase`1.cs
@@ -2,9 +2,6 @@
 
 public abstract class IonSelectOptionBase<TValue>: IonContentComponent
 {
-    [CascadingParameter(Name = nameof(TValue))]
-    public Type? ValueType { get; set; }
-
     /// <summary>
     /// If <b>true</b>, the user cannot interact with the select option.
     /// This property does not apply when <see cref="IonSelect{TValue}.Interface"/>=<see cref="IonSelectInterface.ActionSheet"/>

--- a/src/IonBlazor.Components/Components/IonSelect/IonSelect.razor
+++ b/src/IonBlazor.Components/Components/IonSelect/IonSelect.razor
@@ -27,9 +27,7 @@
             value="@(Value is null ? null : Value.FirstOrDefault())">
     <CascadingValue Value="@(this)" Name="Parent">
         <CascadingValue Value="@Multiple" Name="IsMultiple">
-            <CascadingValue Value="@(Multiple is true ? typeof(TValue[]) : typeof(TValue))" Name="@nameof(TValue)">
-                @ChildContent
-            </CascadingValue>
+            @ChildContent
         </CascadingValue>
     </CascadingValue>
 </ion-select>

--- a/src/IonBlazor.Components/Components/IonSelect/IonSelectOf.razor
+++ b/src/IonBlazor.Components/Components/IonSelect/IonSelectOf.razor
@@ -28,12 +28,10 @@
             value="@(Value is null ? null : Value.FirstOrDefault())">
     <CascadingValue Value="@(this)" Name="Parent">
         <CascadingValue Value="@Multiple" Name="IsMultiple">
-            <CascadingValue Value="@(Multiple is true ? typeof(TItem[]) : typeof(TItem))" Name="@nameof(TItem)">
-                @foreach (var item in ItemsSource.Select((val, idx) => KeyValuePair.Create(idx, val)))
-                {
-                    @ItemTemplate(item)
-                }
-            </CascadingValue>
+            @foreach (var item in ItemsSource.Select((val, idx) => KeyValuePair.Create(idx, val)))
+            {
+                @ItemTemplate(item)
+            }
         </CascadingValue>
     </CascadingValue>
 </ion-select>


### PR DESCRIPTION
The `ValueType` cascading parameter on `IonSelectOptionBase<TValue>` was write-only since its introduction — nothing ever read it. With `Value` now always typed as an array (`TValue[]`), the `typeof(TValue[])` / `typeof(TItem[])` cascade fed a property no option consumed.

Remove the `ValueType` property and the corresponding `<CascadingValue Name=TValue/TItem>` wrapper from both `IonSelect.razor` and `IonSelectOf.razor`, collapsing one nesting level. The `IsMultiple` and `Parent` cascades are left in place.