### PR TITLE
Tag the commit with the package version on NuGet publish

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build, Pack (Publish if requested)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write   # needed to push the release tag when publishing
 
     steps:
       - name: Checkout repository
@@ -143,3 +143,22 @@ jobs:
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
+
+      # Tag the checked-out commit so each NuGet release maps to an exact revision.
+      # Only runs on a real publish (not a dry run) and is idempotent: a re-run that
+      # reuses the same version (same github.run_number) skips an already-existing tag.
+      - name: Tag released version
+        if: ${{ inputs.publish }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG="v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping."
+          else
+            git tag -a "${TAG}" -m "Release ${TAG}"
+            git push origin "${TAG}"
+            echo "Created and pushed tag ${TAG}"
+          fi


### PR DESCRIPTION
After a successful `dotnet nuget push`, tag the checked-out commit as `v{version}` and push the tag to origin, so each NuGet release maps to an exact revision. Gated on the `publish` input (dry runs do not tag) and placed after the push so only packages that reached NuGet get tagged.

The step is idempotent: it skips when the tag already exists on origin, which covers re-runs that reuse the same github.run_number-derived version. Bumps the job permission to `contents: write` so the tag can be pushed via the persisted GITHUB_TOKEN.