### PR TITLE
Fix IonModal sheet breakpoints via a Blazor JS initializer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,30 @@ await JsComponent.InvokeVoidAsync("present", IonElement);
 await JsComponent.InvokeAsync<bool>("dismiss", IonElement);
 ```
 
+## Blazor JS Initializer (sheet-modal breakpoints)
+
+`IonModal`'s `breakpoints` (`number[]`) and `initialBreakpoint` (`number`) are JS **properties** on
+`ion-modal`, not HTML attributes — `breakpoints` has no observed attribute, and Ionic computes its
+internal **sorted** breakpoints array exactly once in `componentDidLoad` (it is not reactive).
+Blazor's JS interop from `OnAfterRenderAsync` runs *after* that one-shot computation (and
+asynchronously over IPC in Server/Hybrid), so assigning the property from .NET is always too late —
+the sheet drag gesture then reduces over an empty array. **Do not "fix" this by moving the interop
+call around; it cannot win that race.**
+
+The working approach: `IonModal` renders the values as `data-ibz-breakpoints` /
+`data-ibz-initial-breakpoint` data attributes (which Blazor *can* emit at element-creation time). A
+**Blazor JS initializer** — `src/IonBlazor.StaticAssets/Typescript/IonBlazor.lib.module.ts`,
+compiled to `wwwroot/IonBlazor.lib.module.js` — copies them onto the real JS properties in a
+microtask, which is guaranteed to run ahead of Stencil's `requestAnimationFrame`-scheduled
+`componentDidLoad`. It covers both prerendered markup (an initial `querySelectorAll` scan) and
+interactively-rendered modals (a `MutationObserver`). Verified end-to-end in MAUI Hybrid (WebView2);
+the microtask-beats-rAF ordering is spec-guaranteed across engines, so Server/WASM follow the same
+path.
+
+Any `*.lib.module.js` in the RCL `wwwroot` is auto-discovered and run by Blazor before the app boots
+— no `index.html`/registration involvement. The `data-ibz-*` attributes are removed by the
+initializer after it applies them, so they never linger in the live DOM.
+
 ## Two-Way Binding (`@bind-Value` / `@bind-Checked`)
 
 Several form-style components support Blazor `@bind`. The pattern is a parallel `…Changed` /

--- a/src/IonBlazor.Components/Components/IonModal/IonModal.razor
+++ b/src/IonBlazor.Components/Components/IonModal/IonModal.razor
@@ -10,16 +10,13 @@
            focus-trap="@focusTrap.AsString()"
            handle="@Handle.AsString()"
            handle-behavior="@HandleBehavior"
-           breakpoints="@Breakpoints"
-           initial-breakpoint="@InitialBreakpoint?.ToString("#.#")"
            is-open="@IsOpen.AsString()"
            keep-contents-mounted="@KeepContentsMounted.AsString()"
            keyboard-close="@KeyboardClose.AsString()"
            mode="@Mode"
            show-backdrop="@ShowBackdrop.AsString()"
            trigger="@Trigger"
-           ibz-id="@_id">
+           data-ibz-breakpoints="@BreakpointsJson"
+           data-ibz-initial-breakpoint="@InitialBreakpointAttr">
     @ChildContent
 </ion-modal>
-
-@((MarkupString)Script)

--- a/src/IonBlazor.Components/Components/IonModal/IonModal.razor.cs
+++ b/src/IonBlazor.Components/Components/IonModal/IonModal.razor.cs
@@ -1,12 +1,8 @@
-﻿using System.Diagnostics;
-
-namespace IonBlazor.Components;
+﻿namespace IonBlazor.Components;
 
 public sealed partial class IonModal : IonJsContentComponent, IIonModeComponent
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
-
-    private readonly string _id = $"ibz-modal-{Stopwatch.GetTimestamp():x}";
 
     private readonly DotNetObjectReference<IonicEventCallback<JsonObject?>> _didDismissReference;
     private readonly DotNetObjectReference<IonicEventCallback<JsonObject?>> _didPresentReference;
@@ -24,17 +20,17 @@ public sealed partial class IonModal : IonJsContentComponent, IIonModeComponent
 
     internal override string JsImportName => nameof(IonModal);
 
-    private string Script => Breakpoints?.Length > 0 ?
-                              $$"""
-                              <script>
-                                var modal = document.querySelector(`[ibz-id="{{_id}}"]`);
-                                if (modal) {
-                                    modal.initialBreakpoint = {{InitialBreakpoint}};
-                                    modal.breakpoints = [{{string.Join(",", Breakpoints)}}];
-                                }
+    // `breakpoints` (number[]) and `initialBreakpoint` are JS properties on ion-modal, and the
+    // internal sorted breakpoints array is computed only once, in the component's componentDidLoad.
+    // Blazor's async JS interop runs after that, so we surface the values as plain data attributes
+    // that a host-side observer copies onto the real JS properties before Stencil loads the element.
+    private string? BreakpointsJson =>
+        Breakpoints?.Length > 0 ? JsonSerializer.Serialize(Breakpoints) : null;
 
-                              </script>
-                              """ : "";
+    private string? InitialBreakpointAttr =>
+        Breakpoints?.Length > 0 && InitialBreakpoint is { } value
+            ? value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : null;
 
     //private readonly DotNetObjectReference<IonicEventCallbackResult<JsonObject?, bool>>? _canDismissCallbackReference;
     //private Func<Task<bool>>? _canDismissCallback;
@@ -454,11 +450,10 @@ public sealed partial class IonModal : IonJsContentComponent, IIonModeComponent
 
         await JsComponent.InvokeVoidAsync("canDismissCallback", IonElement, _canDismissReference);
 
-        if (Breakpoints?.Length > 0)
-        {
-            //await JsComponent.InvokeVoidAsync("initialBreakpoint", _self, InitialBreakpoint);
-            //await JsComponent.InvokeVoidAsync("breakpoints", _self, Breakpoints);
-        }
+        // Note: sheet `breakpoints` / `initialBreakpoint` are applied before Stencil loads the
+        // element by the IonBlazor JS initializer (see Typescript/IonBlazor.lib.module.ts), reading
+        // the data attributes rendered by this component. They cannot be set here because Ionic
+        // computes its sorted breakpoints once, in componentDidLoad, before this interop runs.
 
         if (string.IsNullOrWhiteSpace(EnterAnimation) is false)
             await JsComponent.InvokeVoidAsync("enterAnimation", IonElement, EnterAnimation);

--- a/src/IonBlazor.StaticAssets/Typescript/IonBlazor.lib.module.ts
+++ b/src/IonBlazor.StaticAssets/Typescript/IonBlazor.lib.module.ts
@@ -1,0 +1,96 @@
+// Blazor JavaScript initializer for IonBlazor.
+//
+// `ion-modal`'s `breakpoints` (number[]) and `initialBreakpoint` (number) are JS object/number
+// properties, not HTML attributes — `breakpoints` has no observed attribute, so it can only be
+// set via the element property. Ionic computes the internal *sorted* breakpoints array exactly
+// once, in the component's `componentDidLoad`; it is not reactive. Blazor's JS interop from
+// `OnAfterRenderAsync` runs after that one-shot computation (and, in Server/Hybrid, asynchronously
+// over an IPC channel), so assigning the property from .NET is always too late and the sheet drag
+// gesture then reduces over an empty array ("Reduce of empty array with no initial value").
+//
+// `IonModal` instead renders the values as plain data attributes (which Blazor *can* emit at
+// element-creation time). This initializer — loaded before the app boots — copies them onto the
+// real JS properties the instant the element appears, which is a microtask and therefore runs
+// ahead of Stencil's `requestAnimationFrame`-scheduled `componentDidLoad`. That ordering is
+// guaranteed by spec (microtasks drain before the next animation frame) across every engine
+// (WebView2, WKWebView, Android System WebView, and desktop browsers), so it holds for Blazor
+// WebAssembly, Server, and MAUI Hybrid alike.
+
+type SheetModalElement = Element & {
+    breakpoints?: number[];
+    initialBreakpoint?: number;
+};
+
+const BREAKPOINTS_ATTR = 'data-ibz-breakpoints';
+const INITIAL_BREAKPOINT_ATTR = 'data-ibz-initial-breakpoint';
+
+function applyBreakpoints(element: SheetModalElement): void {
+    const raw = element.getAttribute(BREAKPOINTS_ATTR);
+    if (raw === null) {
+        return;
+    }
+
+    try {
+        element.breakpoints = JSON.parse(raw) as number[];
+
+        const initial = element.getAttribute(INITIAL_BREAKPOINT_ATTR);
+        if (initial !== null && initial !== '') {
+            element.initialBreakpoint = parseFloat(initial);
+        }
+    } catch (error) {
+        console.error('IonBlazor: failed to apply ion-modal sheet breakpoints', raw, error);
+    }
+
+    element.removeAttribute(BREAKPOINTS_ATTR);
+    element.removeAttribute(INITIAL_BREAKPOINT_ATTR);
+}
+
+let installed = false;
+
+function install(): void {
+    if (installed || typeof document === 'undefined') {
+        return;
+    }
+    installed = true;
+
+    // Modals already present in the document (prerendered / static SSR markup).
+    document.querySelectorAll<SheetModalElement>(`ion-modal[${BREAKPOINTS_ATTR}]`).forEach(applyBreakpoints);
+
+    // Modals added later by interactive rendering (WebAssembly / Server / Hybrid).
+    new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+            mutation.addedNodes.forEach(node => {
+                if (node.nodeType !== Node.ELEMENT_NODE) {
+                    return;
+                }
+
+                const element = node as Element;
+                if (element.tagName === 'ION-MODAL') {
+                    applyBreakpoints(element as SheetModalElement);
+                } else {
+                    element
+                        .querySelectorAll<SheetModalElement>(`ion-modal[${BREAKPOINTS_ATTR}]`)
+                        .forEach(applyBreakpoints);
+                }
+            });
+        }
+    }).observe(document.documentElement, { childList: true, subtree: true });
+}
+
+// Blazor WebAssembly (standalone) and Blazor Hybrid (MAUI WebView) call beforeStart/afterStarted.
+export function beforeStart(): void {
+    install();
+}
+
+export function afterStarted(): void {
+    install();
+}
+
+// Blazor Web Apps (Server / WebAssembly / Auto) call the *Web* variants instead.
+export function beforeWebStart(): void {
+    install();
+}
+
+export function afterWebStarted(): void {
+    install();
+}

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.IonModalRendersCorrectly.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.IonModalRendersCorrectly.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithAnimated_RendersCorrectly_value=False.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithAnimated_RendersCorrectly_value=False.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal animated="false" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal animated="false"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithAnimated_RendersCorrectly_value=True.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithAnimated_RendersCorrectly_value=True.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal animated="true" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal animated="true"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithAttributes_RendersCorrectly.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithAttributes_RendersCorrectly.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal id="modal" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal id="modal"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithBackdropDismiss_RendersCorrectly_value=False.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithBackdropDismiss_RendersCorrectly_value=False.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal backdrop-dismiss="false" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal backdrop-dismiss="false"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithBackdropDismiss_RendersCorrectly_value=True.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithBackdropDismiss_RendersCorrectly_value=True.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal backdrop-dismiss="true" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal backdrop-dismiss="true"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithHandle_RendersCorrectly_value=False.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithHandle_RendersCorrectly_value=False.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal handle="false" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal handle="false"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithHandle_RendersCorrectly_value=True.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithHandle_RendersCorrectly_value=True.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal handle="true" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal handle="true"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithIsOpen_RendersCorrectly_value=False.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithIsOpen_RendersCorrectly_value=False.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal is-open="false" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal is-open="false"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithIsOpen_RendersCorrectly_value=True.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithIsOpen_RendersCorrectly_value=True.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal is-open="true" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal is-open="true"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithMode_RendersCorrectly_mode=ios.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithMode_RendersCorrectly_mode=ios.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal mode="ios" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal mode="ios"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithMode_RendersCorrectly_mode=md.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithMode_RendersCorrectly_mode=md.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal mode="md" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal mode="md"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithTrigger_RendersCorrectly.verified.txt
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.WithTrigger_RendersCorrectly.verified.txt
@@ -1,2 +1,1 @@
-﻿<ion-modal trigger="open-modal" ibz-id><p>Modal content</p></ion-modal>
-
+﻿<ion-modal trigger="open-modal"><p>Modal content</p></ion-modal>

--- a/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.cs
+++ b/tests/IonBlazor.UnitTests/Components/IonModal/IonModalTests.cs
@@ -238,6 +238,43 @@ public class IonModalTests : IonTestContext
         invocation.Arguments[1].Should().Be(0.5d);
     }
 
+    // Sheet breakpoints are surfaced as data attributes that the IonBlazor JS initializer applies
+    // to the element's JS properties before Stencil loads it (they cannot be set via interop after
+    // render — Ionic computes its sorted breakpoints once, in componentDidLoad).
+
+    [Fact]
+    public void Breakpoints_RenderAsDataAttributes_ForInitializer()
+    {
+        var cut = Render<IonModal>(parameters => parameters
+            .AddChildContent("<p>Modal content</p>")
+            .Add(p => p.Breakpoints, [0, 0.25, 0.5, 1])
+            .Add(p => p.InitialBreakpoint, 0.25));
+
+        cut.Markup.Should().Contain("""data-ibz-breakpoints="[0,0.25,0.5,1]" """);
+        cut.Markup.Should().Contain("""data-ibz-initial-breakpoint="0.25" """);
+    }
+
+    [Fact]
+    public void Breakpoints_DataAttributes_AbsentWhenNoneSet()
+    {
+        var cut = Render<IonModal>(parameters => parameters
+            .AddChildContent("<p>Modal content</p>"));
+
+        cut.Markup.Should().NotContain("data-ibz-breakpoints");
+        cut.Markup.Should().NotContain("data-ibz-initial-breakpoint");
+    }
+
+    [Fact]
+    public void InitialBreakpoint_DataAttribute_AbsentWhenBreakpointsNotSet()
+    {
+        // initialBreakpoint is meaningless without breakpoints, so it is not emitted on its own.
+        var cut = Render<IonModal>(parameters => parameters
+            .AddChildContent("<p>Modal content</p>")
+            .Add(p => p.InitialBreakpoint, 0.25));
+
+        cut.Markup.Should().NotContain("data-ibz-initial-breakpoint");
+    }
+
     // ---------------------------------------------------------------------------
     // Drag events (sheet / card modal gestures)
     // ---------------------------------------------------------------------------

--- a/tests/IonBlazor.UnitTests/GlobalSetup.cs
+++ b/tests/IonBlazor.UnitTests/GlobalSetup.cs
@@ -5,7 +5,6 @@ namespace IonBlazor.UnitTests;
 public static class GlobalSetup
 {
     private const string ElementReference = "blazor:elementReference";
-    private const string IonBlazorModalId = "ibz-id";
 
     [ModuleInitializer]
     public static void Initialize()
@@ -15,28 +14,12 @@ public static class GlobalSetup
             {
                 if (line.Contains(ElementReference))
                 {
-                    //var index = line.IndexOf(ElementReference, StringComparison.Ordinal);
-                    //line = line.Remove(index, ElementReference.Length + 2 + 36);
-                    if (line.Contains(ElementReference))
-                    {
-                        line = System.Text.RegularExpressions.Regex.Replace(
-                            line,
-                            $"""
-                             \s{ElementReference}=".*?"
-                             """,
-                            string.Empty);
-                    }
-
-                }
-
-                if (line.Contains(IonBlazorModalId))
-                {
                     line = System.Text.RegularExpressions.Regex.Replace(
                         line,
                         $"""
-                         {IonBlazorModalId}="ibz-\w+-[0-9a-f]+"
+                         \s{ElementReference}=".*?"
                          """,
-                        $"{IonBlazorModalId}");
+                        string.Empty);
                 }
 
                 return line;


### PR DESCRIPTION
`ion-modal`'s `breakpoints` (number[]) and `initialBreakpoint` (number) are JS properties, not HTML attributes — `breakpoints` has no observed attribute, and Ionic computes its internal *sorted* breakpoints array exactly once in componentDidLoad (it is not reactive). Both the original injected <script> and a later OnAfterRenderAsync interop attempt fail: the script never runs under interactive render, and interop runs after componentDidLoad (and asynchronously over IPC in Server/Hybrid), so the property is set too late and the sheet drag reduces over an empty array.

Render the values as data-ibz-breakpoints / data-ibz-initial-breakpoint attributes (which Blazor can emit at element-creation time) and add a Blazor JS initializer (IonBlazor.lib.module.ts) that copies them onto the real JS properties in a microtask — guaranteed to run ahead of Stencil's rAF-scheduled componentDidLoad. The initializer handles prerendered markup (initial scan) and interactively-rendered modals (MutationObserver), and removes the data attributes after applying them. Verified end-to-end in MAUI Hybrid (WebView2); the microtask-beats-rAF ordering is spec-guaranteed, so Server/WASM follow the same observer path.

Removes the dead Script property, _id field, the ibz-id / breakpoints / initial-breakpoint attributes, and the now-unused ibz-id Verify scrubber; snapshots updated. Tests assert the data attributes are rendered when (and only when) breakpoints are set. Documents the trap and the data-ibz-* + lib.module.js convention in CLAUDE.md.