### PR TITLE
Make MCP single-entity getter params consistent and forgiving

### DIFF
--- a/src/IonBlazor.Mcp/Tools/ComponentTools.cs
+++ b/src/IonBlazor.Mcp/Tools/ComponentTools.cs
@@ -96,15 +96,25 @@ public static class ComponentTools
         "JsImportName, interfaces, [Parameter] properties (with types and summaries), " +
         "[CascadingParameter] properties, EventCallback events, two-way @bind support " +
         "(value + parallel changed/input callbacks), and JS interop methods. " +
+        "Pass the component name as 'componentName' (the generic alias 'name' is also accepted). " +
         "Component name must be exact PascalCase (e.g. 'IonInput'). " +
         "Generic components use angle-bracket form (e.g. 'IonSelect<TValue>').")]
     public static string GetComponentMetadata(
-        [Description("Exact component name, e.g. 'IonButton', 'IonInput', 'IonSelect<TValue>'.")]
-        string componentName)
+        [Description("Exact component name, e.g. 'IonButton', 'IonInput', 'IonSelect<TValue>'. Optional only because 'name' is accepted as an alias — supply exactly one.")]
+        string? componentName = null,
+        [Description("Alias for 'componentName'. Accepted so a uniform 'name' parameter works across all getter tools.")]
+        string? name = null)
     {
-        var meta = ComponentRegistry.GetMetadata(componentName);
+        var resolved = string.IsNullOrWhiteSpace(componentName) ? name : componentName;
+        if (string.IsNullOrWhiteSpace(resolved))
+            return ToolErrors.MissingName(
+                "get_component_metadata", "componentName", "list_components",
+                [("componentName", componentName), ("name", name)]);
+
+        var meta = ComponentRegistry.GetMetadata(resolved);
         if (meta is null)
-            return $"Component '{componentName}' not found. Use ListComponents to see the full inventory.";
+            return ToolErrors.NotFound(
+                "get_component_metadata", "component", "componentName", resolved, "list_components");
 
         var sb = new StringBuilder();
         sb.Append("# ").AppendLine(meta.Name);

--- a/src/IonBlazor.Mcp/Tools/ServiceTools.cs
+++ b/src/IonBlazor.Mcp/Tools/ServiceTools.cs
@@ -55,15 +55,25 @@ public static class ServiceTools
         "every property with its type, default value and summary, plus any builder properties expanded " +
         "to their delegate signature and the fluent builder's public methods (e.g. ButtonsBuilder, " +
         "InputsBuilder). Use this to learn the exact API for IonAlertService.PresentAsync, " +
-        "IonToastService.PresentAsync, IonLoadingService.CreateAsync, etc. Service name must be " +
-        "exact PascalCase, e.g. 'IonAlertService'.")]
+        "IonToastService.PresentAsync, IonLoadingService.CreateAsync, etc. " +
+        "Pass the service name as 'serviceName' (the generic alias 'name' is also accepted). " +
+        "Service name must be exact PascalCase, e.g. 'IonAlertService'.")]
     public static string GetServiceMetadata(
-        [Description("Exact service name, e.g. 'IonAlertService', 'IonActionSheetService', 'IonToastService', 'IonLoadingService'.")]
-        string serviceName)
+        [Description("Exact service name, e.g. 'IonAlertService', 'IonActionSheetService', 'IonToastService', 'IonLoadingService'. Optional only because 'name' is accepted as an alias — supply exactly one.")]
+        string? serviceName = null,
+        [Description("Alias for 'serviceName'. Accepted so a uniform 'name' parameter works across all getter tools.")]
+        string? name = null)
     {
-        var meta = ServiceRegistry.GetMetadata(serviceName);
+        var resolved = string.IsNullOrWhiteSpace(serviceName) ? name : serviceName;
+        if (string.IsNullOrWhiteSpace(resolved))
+            return ToolErrors.MissingName(
+                "get_service_metadata", "serviceName", "list_services",
+                [("serviceName", serviceName), ("name", name)]);
+
+        var meta = ServiceRegistry.GetMetadata(resolved);
         if (meta is null)
-            return $"Service '{serviceName}' not found. Use ListServices to see the full inventory.";
+            return ToolErrors.NotFound(
+                "get_service_metadata", "service", "serviceName", resolved, "list_services");
 
         var sb = new StringBuilder();
         sb.Append("# ").Append(meta.Name).Append(" — ").AppendLine(meta.Kind.ToString());

--- a/src/IonBlazor.Mcp/Tools/ToolErrors.cs
+++ b/src/IonBlazor.Mcp/Tools/ToolErrors.cs
@@ -1,0 +1,49 @@
+namespace IonBlazor.Mcp.Tools;
+
+/// <summary>
+/// Shared, descriptive error-message builders for the single-entity getter tools
+/// (<c>get_component_metadata</c>, <c>get_service_metadata</c>, <c>get_value_set</c>).
+/// Returning these strings — rather than letting an unhandled exception bubble up as the
+/// opaque "An error occurred invoking '&lt;tool&gt;'" — makes failures self-explanatory to an
+/// LLM caller: every message names the tool, the accepted parameter(s), what was actually
+/// received, and how to discover valid names.
+/// </summary>
+internal static class ToolErrors
+{
+    /// <summary>
+    /// Built when a getter is called with no recognized name parameter supplied. Reports the
+    /// accepted parameter (plus the generic <c>name</c> alias), the values actually received for
+    /// the recognized keys, and the matching <c>list_*</c> tool to discover valid names.
+    /// </summary>
+    public static string MissingName(
+        string toolName,
+        string primaryParameter,
+        string listTool,
+        IReadOnlyList<(string Key, string? Value)> received)
+    {
+        var receivedText = string.Join(", ", received.Select(r => $"{r.Key}={Format(r.Value)}"));
+        return $"Error [{toolName}]: no name supplied. Accepted parameter: '{primaryParameter}' " +
+               $"(alias: 'name'). Received: {receivedText}. " +
+               $"Pass the entity name as '{primaryParameter}' or 'name', or call {listTool} to list valid names.";
+    }
+
+    /// <summary>
+    /// Built when a getter is called with a recognized name parameter that names an entity which
+    /// does not exist. Reports the accepted parameter(s), the requested value, and a hint to call
+    /// the matching <c>list_*</c> tool.
+    /// </summary>
+    public static string NotFound(
+        string toolName,
+        string entityLabel,
+        string primaryParameter,
+        string requested,
+        string listTool)
+    {
+        return $"Error [{toolName}]: {entityLabel} '{requested}' not found. " +
+               $"Accepted parameter: '{primaryParameter}' (alias: 'name'). " +
+               $"Call {listTool} to list valid names.";
+    }
+
+    private static string Format(string? value) =>
+        value is null ? "(null)" : $"\"{value}\"";
+}

--- a/src/IonBlazor.Mcp/Tools/ValueSetTools.cs
+++ b/src/IonBlazor.Mcp/Tools/ValueSetTools.cs
@@ -46,14 +46,25 @@ public static class ValueSetTools
         "Returns every constant in a single IonBlazor value-set class — constant name, the literal string " +
         "value it maps to, and the XML doc summary where present. Use this for the exact options behind a " +
         "parameter like IonInput.Type (IonInputType), IonApp.Mode (IonMode), or IonRippleEffect.Type " +
-        "(IonRippleEffectType). Value-set name must be exact PascalCase, e.g. 'IonInputType'.")]
+        "(IonRippleEffectType). " +
+        "Pass the value-set name as 'valueSetName' (the generic alias 'name' is also accepted). " +
+        "Value-set name must be exact PascalCase, e.g. 'IonInputType'.")]
     public static string GetValueSet(
-        [Description("Exact value-set class name, e.g. 'IonMode', 'IonColor', 'IonInputType', 'IonRippleEffectType'.")]
-        string name)
+        [Description("Exact value-set class name, e.g. 'IonMode', 'IonColor', 'IonInputType', 'IonRippleEffectType'. Optional only because 'name' is accepted as an alias — supply exactly one.")]
+        string? valueSetName = null,
+        [Description("Alias for 'valueSetName'. Accepted so a uniform 'name' parameter works across all getter tools.")]
+        string? name = null)
     {
-        var meta = ValueSetRegistry.GetMetadata(name);
+        var resolved = string.IsNullOrWhiteSpace(valueSetName) ? name : valueSetName;
+        if (string.IsNullOrWhiteSpace(resolved))
+            return ToolErrors.MissingName(
+                "get_value_set", "valueSetName", "list_value_sets",
+                [("valueSetName", valueSetName), ("name", name)]);
+
+        var meta = ValueSetRegistry.GetMetadata(resolved);
         if (meta is null)
-            return $"Value set '{name}' not found. Use ListValueSets to see the full inventory.";
+            return ToolErrors.NotFound(
+                "get_value_set", "value set", "valueSetName", resolved, "list_value_sets");
 
         var sb = new StringBuilder();
         sb.Append("# ").AppendLine(meta.Name);

--- a/tests/IonBlazor.UnitTests/Mcp/GetterToolParameterTests.cs
+++ b/tests/IonBlazor.UnitTests/Mcp/GetterToolParameterTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using IonBlazor.Mcp.Tools;
+
+namespace IonBlazor.UnitTests.Mcp;
+
+/// <summary>
+/// Covers the consistent + forgiving parameter contract on the three single-entity getter tools:
+/// each accepts its typed <c>&lt;entity&gt;Name</c> parameter AND a generic <c>name</c> alias, and
+/// returns a clear (non-exception) error — naming the accepted parameter(s) — when no name is
+/// supplied or the named entity does not exist. Backward compatibility: the typed names
+/// (componentName / serviceName) and value-set's historical <c>name</c> all still resolve.
+/// </summary>
+public class GetterToolParameterTests
+{
+    // ---- get_component_metadata --------------------------------------------------------------
+
+    [Fact]
+    public void GetComponentMetadata_WithComponentName_ReturnsMetadata()
+    {
+        var result = ComponentTools.GetComponentMetadata(componentName: "IonInput");
+
+        result.Should().Contain("# IonInput");
+        result.Should().NotContain("Error [");
+    }
+
+    [Fact]
+    public void GetComponentMetadata_WithNameAlias_ReturnsMetadata()
+    {
+        var result = ComponentTools.GetComponentMetadata(name: "IonInput");
+
+        result.Should().Contain("# IonInput");
+        result.Should().NotContain("Error [");
+    }
+
+    [Fact]
+    public void GetComponentMetadata_WithNoName_ReturnsDescriptiveError()
+    {
+        var result = ComponentTools.GetComponentMetadata();
+
+        result.Should().Contain("get_component_metadata");
+        result.Should().Contain("componentName");
+        result.Should().Contain("'name'");
+        result.Should().Contain("list_components");
+    }
+
+    [Fact]
+    public void GetComponentMetadata_WithUnknownComponent_ReturnsDescriptiveError()
+    {
+        var result = ComponentTools.GetComponentMetadata(componentName: "IonDoesNotExist");
+
+        result.Should().Contain("IonDoesNotExist");
+        result.Should().Contain("not found");
+        result.Should().Contain("componentName");
+        result.Should().Contain("list_components");
+    }
+
+    // ---- get_service_metadata ----------------------------------------------------------------
+
+    [Fact]
+    public void GetServiceMetadata_WithServiceName_ReturnsMetadata()
+    {
+        var result = ServiceTools.GetServiceMetadata(serviceName: "IonAlertService");
+
+        result.Should().Contain("# IonAlertService");
+        result.Should().NotContain("Error [");
+    }
+
+    [Fact]
+    public void GetServiceMetadata_WithNameAlias_ReturnsMetadata()
+    {
+        var result = ServiceTools.GetServiceMetadata(name: "IonAlertService");
+
+        result.Should().Contain("# IonAlertService");
+        result.Should().NotContain("Error [");
+    }
+
+    [Fact]
+    public void GetServiceMetadata_WithNoName_ReturnsDescriptiveError()
+    {
+        var result = ServiceTools.GetServiceMetadata();
+
+        result.Should().Contain("get_service_metadata");
+        result.Should().Contain("serviceName");
+        result.Should().Contain("'name'");
+        result.Should().Contain("list_services");
+    }
+
+    [Fact]
+    public void GetServiceMetadata_WithUnknownService_ReturnsDescriptiveError()
+    {
+        var result = ServiceTools.GetServiceMetadata(serviceName: "IonNopeService");
+
+        result.Should().Contain("IonNopeService");
+        result.Should().Contain("not found");
+        result.Should().Contain("serviceName");
+        result.Should().Contain("list_services");
+    }
+
+    // ---- get_value_set -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetValueSet_WithValueSetName_ReturnsMetadata()
+    {
+        var result = ValueSetTools.GetValueSet(valueSetName: "IonMode");
+
+        result.Should().Contain("# IonMode");
+        result.Should().NotContain("Error [");
+    }
+
+    [Fact]
+    public void GetValueSet_WithNameAlias_StillResolves_ForBackwardCompatibility()
+    {
+        var result = ValueSetTools.GetValueSet(name: "IonMode");
+
+        result.Should().Contain("# IonMode");
+        result.Should().NotContain("Error [");
+    }
+
+    [Fact]
+    public void GetValueSet_WithNoName_ReturnsDescriptiveError()
+    {
+        var result = ValueSetTools.GetValueSet();
+
+        result.Should().Contain("get_value_set");
+        result.Should().Contain("valueSetName");
+        result.Should().Contain("'name'");
+        result.Should().Contain("list_value_sets");
+    }
+
+    [Fact]
+    public void GetValueSet_WithUnknownValueSet_ReturnsDescriptiveError()
+    {
+        var result = ValueSetTools.GetValueSet(valueSetName: "IonNopeSet");
+
+        result.Should().Contain("IonNopeSet");
+        result.Should().Contain("not found");
+        result.Should().Contain("valueSetName");
+        result.Should().Contain("list_value_sets");
+    }
+}


### PR DESCRIPTION
The ionblazor-mcp getter tools used inconsistent parameter names (componentName / serviceName / name), so an LLM caller assuming a uniform name got an opaque "An error occurred invoking '<tool>'" on the mismatched tool.

- Standardize the primary parameter to <entity>Name: rename get_value_set's `name` -> `valueSetName`.
- Accept a generic `name` alias on all three getters; the handler resolves whichever was supplied. Both params are optional in the schema (backward-compatible: componentName/serviceName and the historical `name` all still work).
- Replace opaque failures with descriptive, returned errors (new ToolErrors helper): missing/unrecognized name and not-found both name the accepted parameter(s), the values received, and the matching list_* tool to discover valid names.
- Update each tool/parameter [Description] to document the alias.
- Add GetterToolParameterTests covering both call paths and both error cases for all three getters.